### PR TITLE
Fix CPU usage calculation and improve initial display feedback

### DIFF
--- a/include/system_monitor.hpp
+++ b/include/system_monitor.hpp
@@ -14,6 +14,8 @@ public:
         unsigned long long nice;
         unsigned long long system;
         unsigned long long idle;
+        // Boolean to check if we have valid CPU measurements
+        bool has_valid_measurement = false;
     };
 
     struct MemoryStats {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,17 +141,25 @@ int main() {
         // CPU Usage Percent
         attron(COLOR_PAIR(1));
         print_centered_text(5, "<<< CPU STATUS >>>");
-        draw_status_bar(
-            6, getmaxx(stdscr) / 2 - 10, cpu_stats.usage_percent, 20, true);
+        
+        if (cpu_stats.has_valid_measurement) {
+            // Display the CPU usage
+            draw_status_bar(
+                6, getmaxx(stdscr) / 2 - 10, cpu_stats.usage_percent, 20, true);
+                
+            // Display the CPU status
+            std::string cpu_status = get_status_message(cpu_stats.usage_percent);
+            print_centered_text(8, "Status: %s", cpu_status.c_str());
+        } else {
+            // Display an informational message instead of the status bar
+            print_centered_text(6, "[    Calculating...    ]");
+            print_centered_text(8, "Status: Initializing");
+        }
 
         // Temperature with color coding
         if (cpu_temp > 80) attron(COLOR_PAIR(4));
         else if (cpu_temp > 60) attron(COLOR_PAIR(3));
         print_centered_text(7, "TEMP: %.1f°C", cpu_temp);
-
-        // CPU Status
-        std::string cpu_status = get_status_message(cpu_stats.usage_percent);
-        print_centered_text(8, "Status: %s", cpu_status.c_str());
 
         attroff(COLOR_PAIR(1));
 

--- a/src/system_monitor.cpp
+++ b/src/system_monitor.cpp
@@ -71,26 +71,24 @@ void SystemMonitor::updateCPU() {
             unsigned long long prev_idle = cpu_stats_prev.idle;
             unsigned long long prev_total = cpu_stats_prev.user + cpu_stats_prev.nice + 
                                           cpu_stats_prev.system + cpu_stats_prev.idle;
-            unsigned long long curr_idle = idle;
             unsigned long long curr_total = user + nice + system + idle;
             
             // Ensure there is valid data for calculation
-            if (curr_total > prev_total && curr_idle >= prev_idle) {
+            if (curr_total > prev_total) {
+                unsigned long long curr_idle = idle;
                 unsigned long long total_diff = curr_total - prev_total;
                 unsigned long long idle_diff = curr_idle - prev_idle;
                 
-                // Avoid division by zero and ensure reasonable values
-                if (total_diff > 0) {
-                    cpu_stats.usage_percent = ((total_diff - idle_diff) * 100.0) / total_diff;
-                    
-                    // Sanity check
-                    if (cpu_stats.usage_percent > 100.0) {
-                        cpu_stats.usage_percent = 100.0;
-                    }
-                    
-                    // There is a valid measurement
-                    cpu_stats.has_valid_measurement = true;
+                // Calculate CPU usage percentage
+                cpu_stats.usage_percent = ((total_diff - idle_diff) * 100.0) / total_diff;
+                
+                // Sanity check
+                if (cpu_stats.usage_percent > 100.0) {
+                    cpu_stats.usage_percent = 100.0;
                 }
+                
+                // There is a valid measurement
+                cpu_stats.has_valid_measurement = true;
             }
         } else {
             // Set default values for the first reading

--- a/src/system_monitor.cpp
+++ b/src/system_monitor.cpp
@@ -66,12 +66,6 @@ void SystemMonitor::updateCPU() {
         
         ss >> cpu >> user >> nice >> system >> idle >> iowait >> irq >> softirq >> steal;
         
-        cpu_stats_prev = cpu_stats;
-        cpu_stats.user = user;
-        cpu_stats.nice = nice;
-        cpu_stats.system = system;
-        cpu_stats.idle = idle;
-        
         // Skip first calculation
         if (cpu_stats_prev.user != 0) {
             unsigned long long prev_idle = cpu_stats_prev.idle;
@@ -80,11 +74,36 @@ void SystemMonitor::updateCPU() {
             unsigned long long curr_idle = idle;
             unsigned long long curr_total = user + nice + system + idle;
             
-            unsigned long long total_diff = curr_total - prev_total;
-            unsigned long long idle_diff = curr_idle - prev_idle;
-            
-            cpu_stats.usage_percent = ((total_diff - idle_diff) * 100.0) / total_diff;
+            // Ensure there is valid data for calculation
+            if (curr_total > prev_total && curr_idle >= prev_idle) {
+                unsigned long long total_diff = curr_total - prev_total;
+                unsigned long long idle_diff = curr_idle - prev_idle;
+                
+                // Avoid division by zero and ensure reasonable values
+                if (total_diff > 0) {
+                    cpu_stats.usage_percent = ((total_diff - idle_diff) * 100.0) / total_diff;
+                    
+                    // Sanity check
+                    if (cpu_stats.usage_percent > 100.0) {
+                        cpu_stats.usage_percent = 100.0;
+                    }
+                    
+                    // There is a valid measurement
+                    cpu_stats.has_valid_measurement = true;
+                }
+            }
+        } else {
+            // Set default values for the first reading
+            cpu_stats.usage_percent = 0.0;
+            cpu_stats.has_valid_measurement = false;
         }
+        
+        // Update the previous stats for the next calculation
+        cpu_stats_prev = cpu_stats;
+        cpu_stats.user = user;
+        cpu_stats.nice = nice;
+        cpu_stats.system = system;
+        cpu_stats.idle = idle;
     }
 }
 


### PR DESCRIPTION
This PR addresses an issue where the CPU usage would incorrectly spike to 100% during the first second of application startup.

- Fixed the order of operations in `updateCPU()` to properly store previous values
- Added validation to ensure calculations only occur with valid data
- Added checks to prevent division by zero and cap values at 100%
- Modified the UI to provide clear feedback during initialization